### PR TITLE
Integrate manual CO2 background calibration feature

### DIFF
--- a/components/Sunlight/Sunlight.cpp
+++ b/components/Sunlight/Sunlight.cpp
@@ -517,24 +517,27 @@ int Sunlight::startManualBackgroundCalibration() {
           so to simplicity the process - we just waiting for one (or two if we
           have a synchronization issue) measurement periods...
         */
+        ESP_LOGI(TAG, "Run manual calibration attempt (%d)", attempts + 1);
         vTaskDelay(pdMS_TO_TICKS(CALIBRATION_WAIT_INTERVAL));
         /* First check ErrorStatus, probably the calibration is fail due to
          * non-stable environment */
         if ((error = read_input_registers(CO2_SUNLIGHT_ADDR, ERROR_STATUS, 1)) == 0) {
           if (values[0] & IR1_CALIBRATION_ERROR) {
-            /* Calibration error */
+            ESP_LOGE(TAG, "Calibration error");
             error = SLAVE_FAILURE;
           }
           /* Second, check Calibration status */
           else if ((error = read_holding_registers(CO2_SUNLIGHT_ADDR, HR1, 1)) == 0) {
             /* Is calibration completed? */
             if (values[0] & HR1_BACKGROUND_CALIBRATION) {
+              ESP_LOGI(TAG, "Calibration completed");
               break;
             }
             /* Check timeout, probably we used wrong measurement period to wait
                for calibration complete */
             else if (++attempts == 3) {
               /* Timeout while waiting for calibration */
+              ESP_LOGE(TAG, "All attempts failed to run manual calibration");
               error = SLAVE_FAILURE;
             }
           }

--- a/components/Sunlight/include/Sunlight.h
+++ b/components/Sunlight/include/Sunlight.h
@@ -16,7 +16,8 @@ class Sunlight {
   static const int INTER_PACKET_INTERVAL_MS = 5;
 
   /* Wait interval between manual calibration attempt */
-  static const int CALIBRATION_WAIT_INTERVAL = 4000;
+  static const int CALIBRATION_STATUS_CHECK_INTERVAL = 5000;
+  static const int CALIBRATION_WAIT_COMPLETE_COUNTER = 12;
 
   /* Error codes */
   static const int COMMUNICATION_ERROR = -1;

--- a/components/Sunlight/include/Sunlight.h
+++ b/components/Sunlight/include/Sunlight.h
@@ -15,11 +15,38 @@ class Sunlight {
   /* For baudrate equal 9600 the Modbus 3.5T interval is close to 3.5 ms, we round it to 4 ms*/
   static const int INTER_PACKET_INTERVAL_MS = 5;
 
+  /* Wait interval between manual calibration attempt */
+  static const int CALIBRATION_WAIT_INTERVAL = 4000;
+
   /* Error codes */
   static const int COMMUNICATION_ERROR = -1;
   static const int ILLEGAL_FUNCTION = 1;
   static const int ILLEGAL_DATA_ADDRESS = 2;
   static const int ILLEGAL_DATA_VALUE = 3;
+  static const int SLAVE_FAILURE = -4;
+
+  /* Error statuses */
+  static const uint16_t IR1_FATAL_ERROR = 0x0001u;
+  static const uint16_t IR1_I2C_ERROR = 0x0002u;
+  static const uint16_t IR1_ALGORITHM_ERROR = 0x0004u;
+  static const uint16_t IR1_CALIBRATION_ERROR = 0x0008u;
+  static const uint16_t IR1_SELFDIAG_ERROR = 0x0010u;
+  static const uint16_t IR1_OUT_OF_RANGE_ERROR = 0x0020u;
+  static const uint16_t IR1_MEMORY_ERROR = 0x0040u;
+  static const uint16_t IR1_NO_MEASUREMENT_ERROR = 0x0080u;
+  static const uint16_t IR1_NO_ERROR = 0x0000u;
+
+  /* Sensors registers */
+  static const uint16_t HR1 = 0u;
+  static const uint16_t HR2 = 1u;
+
+  /* Calibration statuses fro HR1 register */
+  static const uint16_t HR1_RESET_VALUE = 0x0000u;
+  static const uint16_t HR1_BACKGROUND_CALIBRATION = 0x0020u;
+
+  /* Calibration command for HR2 register */
+  static const uint16_t HR2_RESTORE_FACTORY_CALIBRATION = 0x7C02u;
+  static const uint16_t HR2_BACKGROUND_CALIBRATION = 0x7C06u;
 
   /* Function codes */
 
@@ -102,6 +129,12 @@ public:
    * @retval true, device restart required
    */
   bool set_measurement_samples(uint16_t number);
+
+  /**
+   * @brief  Make background calibration and report
+   *         error status.
+   */
+  int startManualBackgroundCalibration();
 
   /**
    * @retval true, ABC calibration is enabled on device

--- a/main/RemoteConfig.cpp
+++ b/main/RemoteConfig.cpp
@@ -317,7 +317,7 @@ bool RemoteConfig::_saveConfig() {
 
 bool RemoteConfig::isConfigChanged() { return _configChanged; }
 
-bool RemoteConfig::isCo2CalibrationRequested() { return _config.co2CalibrationRequested; }
+bool RemoteConfig::isCO2CalibrationRequested() { return _config.co2CalibrationRequested; }
 
 bool RemoteConfig::isLedTestRequested() { return _config.ledTestRequested; }
 
@@ -325,8 +325,13 @@ RemoteConfig::Firmware RemoteConfig::getConfigFirmware() { return _config.firmwa
 
 RemoteConfig::Schedule RemoteConfig::getConfigSchedule() { return _config.schedule; }
 
-void RemoteConfig::resetLedTestRequested() {
+void RemoteConfig::resetLedTestRequest() {
   _config.ledTestRequested = false;
+  _saveConfig();
+}
+
+void RemoteConfig::resetCO2CalibrationRequest() {
+  _config.co2CalibrationRequested = false;
   _saveConfig();
 }
 

--- a/main/RemoteConfig.h
+++ b/main/RemoteConfig.h
@@ -38,12 +38,13 @@ public:
 
   // Getter
   bool isConfigChanged();
-  bool isCo2CalibrationRequested();
+  bool isCO2CalibrationRequested();
   bool isLedTestRequested();
   Firmware getConfigFirmware();
   Schedule getConfigSchedule();
 
-  void resetLedTestRequested();
+  void resetLedTestRequest();
+  void resetCO2CalibrationRequest();
 
 private:
   const char *const TAG = "RemoteConfig";

--- a/main/Sensor.cpp
+++ b/main/Sensor.cpp
@@ -456,7 +456,8 @@ void Sensor::_applyIteration(AirgradientClient::OpenAirMaxPayload &data) {
     if (_averageMeasure.o3WorkingElectrode == DEFAULT_INVALID_VOLT) {
       _averageMeasure.o3WorkingElectrode = data.o3WorkingElectrode;
     } else {
-      _averageMeasure.o3WorkingElectrode = _averageMeasure.o3WorkingElectrode + data.o3WorkingElectrode;
+      _averageMeasure.o3WorkingElectrode =
+          _averageMeasure.o3WorkingElectrode + data.o3WorkingElectrode;
     }
     _o3WEIterationOkCount = _o3WEIterationOkCount + 1;
   }
@@ -465,7 +466,8 @@ void Sensor::_applyIteration(AirgradientClient::OpenAirMaxPayload &data) {
     if (_averageMeasure.o3AuxiliaryElectrode == DEFAULT_INVALID_VOLT) {
       _averageMeasure.o3AuxiliaryElectrode = data.o3AuxiliaryElectrode;
     } else {
-      _averageMeasure.o3AuxiliaryElectrode = _averageMeasure.o3AuxiliaryElectrode + data.o3AuxiliaryElectrode;
+      _averageMeasure.o3AuxiliaryElectrode =
+          _averageMeasure.o3AuxiliaryElectrode + data.o3AuxiliaryElectrode;
     }
     _o3AEIterationOkCount = _o3AEIterationOkCount + 1;
   }
@@ -474,7 +476,8 @@ void Sensor::_applyIteration(AirgradientClient::OpenAirMaxPayload &data) {
     if (_averageMeasure.no2WorkingElectrode == DEFAULT_INVALID_VOLT) {
       _averageMeasure.no2WorkingElectrode = data.no2WorkingElectrode;
     } else {
-      _averageMeasure.no2WorkingElectrode = _averageMeasure.no2WorkingElectrode + data.no2WorkingElectrode;
+      _averageMeasure.no2WorkingElectrode =
+          _averageMeasure.no2WorkingElectrode + data.no2WorkingElectrode;
     }
     _no2WEIterationOkCount = _no2WEIterationOkCount + 1;
   }
@@ -483,7 +486,8 @@ void Sensor::_applyIteration(AirgradientClient::OpenAirMaxPayload &data) {
     if (_averageMeasure.no2AuxiliaryElectrode == DEFAULT_INVALID_VOLT) {
       _averageMeasure.no2AuxiliaryElectrode = data.no2AuxiliaryElectrode;
     } else {
-      _averageMeasure.no2AuxiliaryElectrode = _averageMeasure.no2AuxiliaryElectrode + data.no2AuxiliaryElectrode;
+      _averageMeasure.no2AuxiliaryElectrode =
+          _averageMeasure.no2AuxiliaryElectrode + data.no2AuxiliaryElectrode;
     }
     _no2AEIterationOkCount = _no2AEIterationOkCount + 1;
   }
@@ -586,15 +590,18 @@ void Sensor::_calculateMeasuresAverage() {
   }
 
   if (_o3AEIterationOkCount > 0) {
-    _averageMeasure.o3AuxiliaryElectrode = _averageMeasure.o3AuxiliaryElectrode / _o3AEIterationOkCount;
+    _averageMeasure.o3AuxiliaryElectrode =
+        _averageMeasure.o3AuxiliaryElectrode / _o3AEIterationOkCount;
   }
 
   if (_no2WEIterationOkCount > 0) {
-    _averageMeasure.no2WorkingElectrode = _averageMeasure.no2WorkingElectrode / _no2WEIterationOkCount;
+    _averageMeasure.no2WorkingElectrode =
+        _averageMeasure.no2WorkingElectrode / _no2WEIterationOkCount;
   }
 
   if (_no2AEIterationOkCount > 0) {
-    _averageMeasure.no2AuxiliaryElectrode = _averageMeasure.no2AuxiliaryElectrode / _no2AEIterationOkCount;
+    _averageMeasure.no2AuxiliaryElectrode =
+        _averageMeasure.no2AuxiliaryElectrode / _no2AEIterationOkCount;
   }
 
   if (_afeTempIterationOkCount > 0) {

--- a/main/Sensor.cpp
+++ b/main/Sensor.cpp
@@ -200,6 +200,18 @@ void Sensor::printMeasures() {
 
 AirgradientClient::OpenAirMaxPayload Sensor::getLastAverageMeasure() { return _averageMeasure; }
 
+bool Sensor::co2AttemptManualCalibration() {
+  ESP_LOGI(TAG, "Attempt to do manual calibration");
+  int error = co2_->startManualBackgroundCalibration();
+  if (error != 0) {
+    ESP_LOGE(TAG, "CO2 calibration Failed!");
+    return false;
+  }
+
+  ESP_LOGD(TAG, "CO2 calibration Success!");
+  return true;
+}
+
 void Sensor::_measure(AirgradientClient::OpenAirMaxPayload &data) {
   // Set measure data to invalid for indication if respective sensor failed
   data.rco2 = DEFAULT_INVALID_CO2;

--- a/main/Sensor.h
+++ b/main/Sensor.h
@@ -26,6 +26,7 @@ public:
   bool startMeasures(int iterations, int intervalMs);
   void printMeasures();
   AirgradientClient::OpenAirMaxPayload getLastAverageMeasure();
+  bool co2AttemptManualCalibration();
 
 private:
   const char *const TAG = "Sensor";

--- a/main/max.cpp
+++ b/main/max.cpp
@@ -150,7 +150,7 @@ extern "C" void app_main(void) {
   if (g_remoteConfig.isLedTestRequested()) {
     g_statusLed.set(StatusLed::Blink, 5000, 100);
     vTaskDelay(pdMS_TO_TICKS(5000));
-    g_remoteConfig.resetLedTestRequested();
+    g_remoteConfig.resetLedTestRequest();
   }
 
   // Reset external WDT
@@ -188,8 +188,9 @@ extern "C" void app_main(void) {
         "One or more sensor were failed to initialize, will not measure those on this iteration");
   }
 
-  if (g_remoteConfig.isCo2CalibrationRequested()) {
+  if (g_remoteConfig.isCO2CalibrationRequested()) {
     sensor.co2AttemptManualCalibration();
+    g_remoteConfig.resetCO2CalibrationRequest();
   }
 
   // Start measure sensor sequence that if success,

--- a/main/max.cpp
+++ b/main/max.cpp
@@ -189,7 +189,7 @@ extern "C" void app_main(void) {
   }
 
   if (g_remoteConfig.isCo2CalibrationRequested()) {
-    // TODO: Implement!
+    sensor.co2AttemptManualCalibration();
   }
 
   // Start measure sensor sequence that if success,


### PR DESCRIPTION
## Changes

1. New function to Sunlight library to start CO2 calibration
2. Total wait calibration to complete before timeout is 60s, but sensor could take longer to complete. So timeout doesn't mean it failed
3. CO2 calibration started based on remote configuration: `co2CalibrationRequested`
