### PR TITLE
Improve led indicator for better information

### DIFF
--- a/main/StatusLed.cpp
+++ b/main/StatusLed.cpp
@@ -133,6 +133,7 @@ void StatusLed::_start(void *params) {
       } else {
         gpio_set_level(pLed->_ioLed, 0);
       }
+      currentStatus.mode = lastStatus.mode;
       currentStatus.duration = 0;
       waitNotificationTick = portMAX_DELAY;
       continue;

--- a/main/StatusLed.cpp
+++ b/main/StatusLed.cpp
@@ -120,29 +120,19 @@ void StatusLed::_start(void *params) {
 
     // Check if duration is UP and duration is not set to forever (0)
     if ((MILLIS() - blinkStartTime) > currentStatus.duration && currentStatus.duration > 0) {
-      if (lastStatus.duration == 0) {
+      if (lastStatus.duration == 0 && lastStatus.mode == Blink) {
         // If last status duration expected to forever, go back to last status after this animation
         currentStatus = lastStatus;
-
-        switch (lastStatus.mode) {
-        case Off:
-          gpio_set_level(pLed->_ioLed, 0);
-          waitNotificationTick = portMAX_DELAY;
-          break;
-        case On:
-          gpio_set_level(pLed->_ioLed, 1);
-          waitNotificationTick = portMAX_DELAY;
-          break;
-        case Blink:
-          gpio_set_level(pLed->_ioLed, 1); // turn on first
-          waitNotificationTick = currentStatus.interval / portTICK_PERIOD_MS;
-          blinkStartTime = MILLIS();
-          break;
-        }
-        continue;
+        gpio_set_level(pLed->_ioLed, 1); // turn on first
+        waitNotificationTick = currentStatus.interval / portTICK_PERIOD_MS;
+        blinkStartTime = MILLIS();
       }
 
-      gpio_set_level(pLed->_ioLed, 0);
+      if (lastStatus.mode == On) {
+        gpio_set_level(pLed->_ioLed, 1);
+      } else {
+        gpio_set_level(pLed->_ioLed, 0);
+      }
       currentStatus.duration = 0;
       waitNotificationTick = portMAX_DELAY;
       continue;

--- a/main/StatusLed.h
+++ b/main/StatusLed.h
@@ -15,6 +15,12 @@ class StatusLed {
 public:
   enum Mode { Off, On, Blink };
 
+  struct Status {
+    Mode mode;
+    int duration;
+    int interval;
+  };
+
   StatusLed(gpio_num_t ioLed);
   ~StatusLed();
 
@@ -26,8 +32,8 @@ public:
    * @brief set led notification based on provided Mode
    *
    * @param mode what mode to set to led notification
-   * @param durationMs blink duration; If 0, then blink is set to forever until Set() called again 
-   * @param intervalMs interval between each blink 
+   * @param durationMs blink duration; If 0, then blink is set to forever until Set() called again
+   * @param intervalMs interval between each blink
    */
   void set(Mode mode, int durationMs = 0, int intervalMs = 0);
 
@@ -36,10 +42,8 @@ private:
 
   gpio_num_t _ioLed = GPIO_NUM_MAX;
   TaskHandle_t _taskHandle = NULL;
-  bool _isRunning = false;
-  Mode _lastMode = Off;
-  int _lastDuration = 0;
-  int _lastInterval = 0;
+  bool _isRunning = false; // TODO: Handle better
+  Status _newStatus;
 
   static void _start(void *params);
 };

--- a/main/max.cpp
+++ b/main/max.cpp
@@ -180,7 +180,7 @@ extern "C" void app_main(void) {
 
   Sensor sensor(bus_handle);
   if (!sensor.init()) {
-    g_statusLed.set(StatusLed::Blink, 400, 100);
+    g_statusLed.set(StatusLed::Blink, 2000, 500);
     ESP_LOGW(
         TAG,
         "One or more sensor were failed to initialize, will not measure those on this iteration");
@@ -428,7 +428,7 @@ bool initializeCellularNetwork(unsigned long wakeUpCounter) {
 
   if (wakeUpCounter == 0) {
     // When currently initializing network, indicate using blink animation
-    g_statusLed.set(StatusLed::Blink, 600, 100);
+    g_statusLed.set(StatusLed::Blink, 400, 100);
   }
 
   g_ceAgSerial = new AirgradientUART();
@@ -452,7 +452,7 @@ bool initializeCellularNetwork(unsigned long wakeUpCounter) {
     if (g_agClient->begin(g_serialNumber)) {
       // Connected
       if (wakeUpCounter == 0) {
-        g_statusLed.set(StatusLed::Blink, 800, 100);
+        g_statusLed.set(StatusLed::Blink, 600, 100);
         vTaskDelay(pdMS_TO_TICKS(1000));
       }
       break;
@@ -512,14 +512,14 @@ bool sendMeasuresWhenReady(unsigned long wakeUpCounter, PayloadCache &payloadCac
   if (!success) {
     // Consider network has a problem, retry in next schedule
     ESP_LOGE(TAG, "send measures failed, retry in next schedule");
-    g_statusLed.set(StatusLed::Blink, 2000, 500); // Always show indicator when failed post
+    g_statusLed.set(StatusLed::Blink, 3000, 500); // Always show indicator when failed post
     vTaskDelay(pdMS_TO_TICKS(2000));
     return false;
   }
 
   if (wakeUpCounter == 0) {
     // Notify post success
-    g_statusLed.set(StatusLed::Blink, 1000, 100);
+    g_statusLed.set(StatusLed::Blink, 800, 100);
   }
 
   payloadCache.clean();


### PR DESCRIPTION
## Changes

### Powered On (1st boot)

1. Led indicator turned on right away
2. Quick blink 2x when starting initialize CE card and attempt to connect to network
3. Quick blink 3x when successfully connect to network
4. Quick blink 4x when successfully post 1st measurement to server
5. Slow blink (500ms interval) 2x if there's one or more sensor failed to initialize
6. Slow blink (500ms interval) 3x when failed post to server
7. Slow blink (1000ms interval) 5x when failed connect to network before retry

### Every wakeup cycle

1. Led indicator is off unless there's error
2. Slow blink (500ms interval) 2x if there's one or more sensor failed to initialize
3. Slow blink (500ms interval) 3x when failed post to server
