### PR TITLE
Ensure successful POST measures on first boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # Firmware for the Open Air Max, uses airgradient-client and airgradient-ota
+
+## Led indicator
+
+### Powered On (1st boot)
+
+1. Led indicator turned on right away
+2. Quick blink 2x when starting initialize CE card and attempt to connect to network
+3. Quick blink 3x when successfully connect to network
+4. Quick blink 4x when successfully post 1st measurement to server
+5. Slow blink (500ms interval) 2x if there's one or more sensor failed to initialize
+6. Slow blink (500ms interval) 3x when failed post to server
+7. Slow blink (1000ms interval) 5x when failed connect to network before retry
+
+### Every wakeup cycle
+
+1. Led indicator is off unless there's error
+2. Slow blink (500ms interval) 2x if there's one or more sensor failed to initialize
+3. Slow blink (500ms interval) 3x when failed post to server

--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@
 2. Quick blink 2x when starting initialize CE card and attempt to connect to network
 3. Quick blink 3x when successfully connect to network
 4. Quick blink 4x when successfully post 1st measurement to server
-5. Slow blink (500ms interval) 2x if there's one or more sensor failed to initialize
-6. Slow blink (500ms interval) 3x when failed post to server
-7. Slow blink (500ms interval) 4x when failed post to server because CE card problem (or network) and attempt to ensure connection failed
-8. Slow blink (500ms interval) 6x when give up after 3 attempts of failed post measures because of network reasons
-9. Slow blink (1000ms interval) 5x when failed connect to network before retry
+5. Slow blink 2x if there's one or more sensor failed to initialize
+6. Slow blink 3x when failed post to server
+7. Slow blink 4x when failed post to server because of server issue
+8. Slow blink 5x when ensure connection failed after unsuccessful post to server
+9. Slow blink 6x when give up after 3 attempts of failed post measures because of network reasons
+10. Slow blink 10x when failed connect to network before retry
 
 ### Every wakeup cycle
 
 1. Led indicator is off unless there's error
-2. Slow blink (500ms interval) 2x if there's one or more sensor failed to initialize
-3. Slow blink (500ms interval) 3x when failed post to server
+2. Slow blink 2x if there's one or more sensor failed to initialize
+3. Slow blink 3x when failed post to server

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 4. Quick blink 4x when successfully post 1st measurement to server
 5. Slow blink (500ms interval) 2x if there's one or more sensor failed to initialize
 6. Slow blink (500ms interval) 3x when failed post to server
-7. Slow blink (1000ms interval) 5x when failed connect to network before retry
+7. Slow blink (500ms interval) 4x when failed post to server because CE card problem (or network) and attempt to ensure connection failed
+8. Slow blink (500ms interval) 6x when give up after 3 attempts of failed post measures because of network reasons
+9. Slow blink (1000ms interval) 5x when failed connect to network before retry
 
 ### Every wakeup cycle
 

--- a/main/max.cpp
+++ b/main/max.cpp
@@ -526,17 +526,16 @@ bool sendMeasuresWhenReady(unsigned long wakeUpCounter, PayloadCache &payloadCac
       break;
     }
 
-    // Check if this is first boot, if not retry in next schedule
     if (wakeUpCounter != 0) {
-      // retry in next schedule
+      // Check if this is first boot, if not retry in next schedule
       ESP_LOGE(TAG, "Send measures failed, retry in next schedule");
       g_statusLed.set(StatusLed::Blink, 3000, 500); // Run failed post led indicator
       vTaskDelay(pdMS_TO_TICKS(2000));
       break;
     }
 
-    // Check post failed if because of client is not ready
     if (g_agClient->isClientReady() == false) {
+      // Client is not ready
       g_statusLed.set(StatusLed::Blink, 3000, 500); // Run failed post led indicator
       ESP_LOGE(TAG, "Send measures failed because of client is not ready, ensuring connection...");
       g_ceAgSerial->setDebug(true);

--- a/main/max.cpp
+++ b/main/max.cpp
@@ -14,6 +14,7 @@
 #include "esp_console.h"
 #include "driver/usb_serial_jtag.h"
 #include "driver/usb_serial_jtag_vfs.h"
+#include "esp_system.h"
 #include "hal/gpio_types.h"
 #include "nvs_flash.h"
 #include "esp_err.h"
@@ -505,16 +506,60 @@ bool sendMeasuresWhenReady(unsigned long wakeUpCounter, PayloadCache &payloadCac
     tmp.signal = signalStrength;
     payloads.push_back(tmp);
   }
-  // TODO: Make sure send data success when wake up counter is 0
 
   // Attempt to send
-  bool success = g_agClient->httpPostMeasures(g_remoteConfig.getConfigSchedule().pm02, payloads);
-  if (!success) {
-    // Consider network has a problem, retry in next schedule
-    ESP_LOGE(TAG, "send measures failed, retry in next schedule");
-    g_statusLed.set(StatusLed::Blink, 3000, 500); // Always show indicator when failed post
-    vTaskDelay(pdMS_TO_TICKS(2000));
-    return false;
+  bool postSuccess = false;
+  int attemptCounter = 0;
+  do {
+    attemptCounter = attemptCounter + 1;
+    postSuccess = g_agClient->httpPostMeasures(g_remoteConfig.getConfigSchedule().pm02, payloads);
+    if (postSuccess) {
+      // post success, exit the loop
+      break;
+    }
+
+    // Run failed post led indicator
+    g_statusLed.set(StatusLed::Blink, 3000, 500);
+
+    // Check if this is first boot, if not retry in next schedule
+    if (wakeUpCounter != 0) {
+      // retry in next schedule
+      ESP_LOGE(TAG, "Send measures failed, retry in next schedule");
+      vTaskDelay(pdMS_TO_TICKS(2000));
+      break;
+    }
+
+    // check post failed if because of client is not ready
+    if (g_agClient->isClientReady() == false) {
+      ESP_LOGE(TAG, "Send measures failed because of client is not ready, ensuring connection...");
+      g_ceAgSerial->setDebug(true);
+      if (g_agClient->ensureClientConnection(true) == false) {
+        ESP_LOGE(TAG, "Failed ensuring client connection, system restart in 4s");
+        g_statusLed.set(StatusLed::Blink, 4000, 500);
+        vTaskDelay(pdMS_TO_TICKS(4000));
+        esp_restart();
+      }
+      g_ceAgSerial->setDebug(false);
+
+      ESP_LOGI(TAG, "Client is ready now, retry post measures");
+      continue;
+    }
+
+    if (g_agClient->isRegisteredOnAgServer() == false) {
+      // TODO: What to do here? maybe just add new led indicator and just restart
+    }
+
+    // TODO: in here because of other status code, then what? maybe just retry in next schedule because this is server issue
+
+  } while (attemptCounter < 3);
+
+  // Check if still first boot, client is not ready and after 3 attempts is still failed post measures
+  if (wakeUpCounter == 0 && !postSuccess && g_agClient->isClientReady() == false) {
+    ESP_LOGE(TAG, "Give up after 3 attempts of failed post measures because of network reasons, "
+                  "restart systems in 6s");
+    g_statusLed.set(StatusLed::Blink, 6000, 500);
+    vTaskDelay(pdMS_TO_TICKS(6000));
+    esp_restart();
   }
 
   if (wakeUpCounter == 0) {

--- a/main/max.cpp
+++ b/main/max.cpp
@@ -474,6 +474,9 @@ bool initializeCellularNetwork(unsigned long wakeUpCounter) {
   g_ceAgSerial->setDebug(false);
   g_networkReady = true;
 
+  // Wait for a moment for CE card is ready for transmission
+  vTaskDelay(pdMS_TO_TICKS(2000));
+
   return true;
 }
 
@@ -545,7 +548,8 @@ bool sendMeasuresWhenReady(unsigned long wakeUpCounter, PayloadCache &payloadCac
       }
       g_ceAgSerial->setDebug(false);
 
-      ESP_LOGI(TAG, "Client is ready now, retry post measures");
+      ESP_LOGI(TAG, "Client is ready now, retry post measures in 5s");
+      vTaskDelay(pdMS_TO_TICKS(5000));
       continue;
     }
 
@@ -554,8 +558,9 @@ bool sendMeasuresWhenReady(unsigned long wakeUpCounter, PayloadCache &payloadCac
     }
 
     ESP_LOGW(TAG, "Send measures failed because of server issue, retry in next schedule");
-    g_statusLed.set(StatusLed::Blink, 4000, 500); // Run failed post led indicator because of server issue
-    vTaskDelay(pdMS_TO_TICKS(2000));
+    // Run failed post led indicator because of server issue
+    g_statusLed.set(StatusLed::Blink, 4000, 500);
+    vTaskDelay(pdMS_TO_TICKS(3000));
     break;
 
   } while (attemptCounter < 3 && !postSuccess);


### PR DESCRIPTION
## Changes

1. Retry to 3 make successful post measures before giving up (system restart)
2. If on those attempts network is disconnected or CE card error, it will attempt to connect again 1 times that if failed it will give up (system restart)
3. If on those attempts error because of server issue or monitor is not registered on dashboard, it retry post measures on the next schedule
4. Add led indicator meaning section on `README.md`
5. Bump AirgradientClient submodule regarding add another network attach check when checking if service ready