### PR TITLE
Send measures through mqtt if mqtt broker host provided from Airgradient Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,104 @@ If, on the first boot, the **boot button** is held for 5 seconds or longer, the 
 
 To exit, either **save the new settings**, press the **Exit** button on the home page, or hold the **boot button** again for 5 seconds or longer.  
 
+## Transmission
+
+Has 2 network options, Cellular and WiFi that can be choose from _System Settings Portal_. Default set to *Cellular*.
+
+### 1. Fetch Configuration
+
+Fetch remote configuration from airgradient server every 1 hour, and configuration will be applied on the next wakeup cycle
+
+### 2. FOTA Update
+
+Check for firmware update every 1 hour, then fetch and apply if firmware version is not latest
+
+### 3. Send Measurements
+
+Payload format is sent based on what is the network options
+
+#### Cellular
+
+> Applied when transmit through HTTP and MQTT
+
+Device operates on a regular schedule, attempting to send payload every 9 minutes. Each payload contains a set of comma-separated values. The first value is an **`interval`** number, which serves as a reference for the timestamping of the subsequent measurements. After that, the payload contains three distinct sets of sensor measurements. Each set represents a snapshot of the device's sensor readings taken at a 3-minute interval. The measurements are always in the same order:
+
+- CO2
+- Temperature
+- Humidity
+- PM1.0
+- PM2.5
+- PM10
+- TVOC
+- NOx
+- PM 0.3 Particle Count 
+- Signal Strength in dbm
+- Battery Voltage
+- Solar Panel Voltage
+- O3 Working Electrode (WE) → _O-M-1PPSTON-CE_ only
+- O3 Auxiliary Electrode (AE) → _O-M-1PPSTON-CE_ only
+- NO2 Working Electrode (WE) → _O-M-1PPSTON-CE_ only
+- NO2 Auxiliary Electrode (AE) → _O-M-1PPSTON-CE_ only
+- AFE Temperature → _O-M-1PPSTON-CE_ only
+
+**Example Payload Breakdown**
+
+A typical payload might look like this:
+
+```
+180,452,285,751,163,277,295,34012,20429,3225,-69,1124,14,580981,581369,581319,582400,5796,450,286,751,170,283,300,34140,20589,3272,-69,1124,15,581000,581400,581388,582456,5795,446,286,753,167,287,302,34139,20577,3237,-69,1124,15,581013,581438,581350,582494,5796
+```
+
+In this example:
+
+- `180` → The `interval` value at the start
+- `452,...,5796` → The first measurements set 
+- `450,...,5795` → The second measurements set 
+- `446,...,5796` → The third measurements set 
+
+**Data Scaling for Efficiency**
+
+To reduce the payload size and still maintain precision for decimal values, certain measurements are scaled up before transmission. Developers must divide these values by a specific factor to get the actual reading:
+
+- **Divide by 10**: `Temperature`, `Humidity`, `PM1.0`, `PM2.5`, `PM10`, and `AFE Temperature`.
+- **Divide by 100**: `Battery Voltage` and `Solar Panel Voltage`.
+- **Divide by 1000**: `O3 WE`, `O3 AE`, `NO2 WE`, and `NO2 AE`.
+
+For example, a transmitted `Temperature` value of `285` should be divided by 10 to get the actual reading of `28.5`.
+
+
+**Handling Data Loss**
+
+The device has a built-in caching mechanism to handle network outages. If a scheduled transmission fails, the measurements are stored locally. On the next successful transmission, the device will send the new measurements along with the previously cached ones. This means you may receive payloads with more than three sets of measurements. For example, a payload could contain six measurements if one transmission cycle was missed. This ensures data integrity and prevents permanent data loss during temporary network disruptions.
+
+> This caching is not permanent. If the device experiences a power loss, any cached data that has not yet been transmitted will be lost.
+
+#### WiFi
+
+> Applied when transmit through HTTP
+
+Data from the device is packaged into a JSON payload. The device operates on a regular schedule, sending a new payload every 3 minutes. Each payload contains a single set of sensor measurements. Device transmits measurements as they are taken. There is no data caching or retransmission mechanism built into the device. If a transmission fails, the data for that 3-minute interval is not resent.
+
+**Example Payload Breakdown**
+
+```json
+{
+  "rco2": 452, // CO2
+  "atmp": 28.5, // Temperature
+  "rhum": 75.1, // Humidity 
+  "pm01": 16.3, // PM1.0
+  "pm25": 27.7, // PM2.5
+  "pm10": 29.5, // PM10
+  "tvocRaw": 34012, // TVOC Raw
+  "noxRaw": 20429, // NOx Raw
+  "pm003Count": 3225, // PM 0.3 Particle Count
+  "wifi": -69, // Wifi Signal
+  "volt": 11.24, // Battery Volt
+  "light": 1.4, // Solar Panel Vold
+  "measure0": 580.981, // O3 WE
+  "measure1": 581.369, // O3 AE
+  "measure2": 581.319, // NO2 WE
+  "measure3": 582.400, // NO2 AE
+  "measure4": 579.6 // AFE Temperature
+}
+```

--- a/main/Configuration.cpp
+++ b/main/Configuration.cpp
@@ -199,7 +199,7 @@ bool Configuration::parseRemoteConfig(const std::string &config) {
     ESP_LOGW(TAG, "firmware field not found or not an object");
   }
 
-  // mqttBrokerUrl 
+  // mqttBrokerUrl
   if (root["mqttBrokerUrl"].is<const char *>()) {
     str_val = root["mqttBrokerUrl"].as<std::string>();
     if (_config.mqttBrokerUrl != str_val) {
@@ -530,6 +530,8 @@ bool Configuration::isWifiConfigured() { return _config.isWifiConfigured; }
 bool Configuration::runSystemSettings() { return _config.runSystemSettings; }
 
 std::string Configuration::getAPN() { return _config.apn; }
+
+std::string Configuration::getMqttBrokerUrl() { return _config.mqttBrokerUrl; }
 
 bool Configuration::set(Config config) {
   _config = config;

--- a/main/Configuration.h
+++ b/main/Configuration.h
@@ -36,6 +36,7 @@ public:
     bool isWifiConfigured;
     bool runSystemSettings;
     std::string apn;
+    std::string mqttBrokerUrl;
   };
 
   Configuration() {}

--- a/main/Configuration.h
+++ b/main/Configuration.h
@@ -26,17 +26,19 @@ public:
   enum Model { O_M_1PPST_CE = 0, O_M_1PPSTON_CE };
 
   struct Config {
+    // Remote
     int abcDays;
     bool co2CalibrationRequested;
     bool ledTestRequested;
     std::string model;
     Schedule schedule;
     Firmware firmware;
+    std::string mqttBrokerUrl;
+    // Local
     NetworkOption networkOption;
     bool isWifiConfigured;
     bool runSystemSettings;
     std::string apn;
-    std::string mqttBrokerUrl;
   };
 
   Configuration() {}
@@ -58,6 +60,7 @@ public:
   bool isWifiConfigured();
   bool runSystemSettings();
   std::string getAPN();
+  std::string getMqttBrokerUrl();
 
   // Setter
   bool set(Config config);

--- a/main/max.cpp
+++ b/main/max.cpp
@@ -52,7 +52,7 @@
 // Wake up counter that saved on Low Power memory
 RTC_DATA_ATTR unsigned long xWakeUpCounter = 0;
 
-// Hold the index of measures queue on which http post should start send data
+// Hold the index of measures queue on which http post should start send measures
 // eg. xHttpCacheQueueIndex = 3, then for [q1, q2, q3, q4, q5, q6] should only send q4, q5, q6
 RTC_DATA_ATTR unsigned long xHttpCacheQueueIndex = 0;
 
@@ -299,8 +299,8 @@ extern "C" void app_main(void) {
 
   if (g_configuration.getNetworkOption() == NetworkOption::Cellular) {
     // Attempt send post through HTTP first
-    // If success and send data through MQTT not enabled, then clean the cache while make sure xHttpCacheQueueIndex reset
-    // Attempt send data through MQTT if its enabled
+    // If success and send measures through MQTT not enabled, then clean the cache while make sure xHttpCacheQueueIndex reset
+    // Attempt send measures through MQTT if its enabled
     PayloadCache payloadCache(MAX_PAYLOAD_CACHE);
     payloadCache.push(&averageMeasures);
     bool success = sendMeasuresByCellular(wakeUpCounter, payloadCache);
@@ -884,8 +884,8 @@ bool sendMeasuresUsingMqtt(unsigned long wakeUpCounter, PayloadCache &payloadCac
 
   // When success, clean the cache (because already send to both HTTP and MQTT)
   //  and also reset xHttpCacheQueueIndex to make sure post through both HTTP and MQTT start fresh
-  // But if failed, since HTTP already send all the data on cache,
-  //  set xHttpCacheQueueIndex to the cache current size as the start index of which HTTP post data from queue
+  // But if failed, since HTTP already send all the measures on cache,
+  //  set xHttpCacheQueueIndex to the cache current size as the start index of which HTTP post measures from queue
   bool success = g_agClient->mqttPublishMeasures(payload);
   if (success) {
     payloadCache.clean();


### PR DESCRIPTION
## Changes

Send measures through MQTT if MQTT broker host provided from cloud configuration. Currently only applied when network option is Cellular. 

- `xHttpCacheQueueIndex` is introduced to hold the index of cached measures queue on which http post should start send data
- Measures cache only clean if HTTP post success with MQTT not enabled and send through MQTT success
- If MQTT failed send data and since HTTP already send all the data on cache, set ``xHttpCacheQueueIndex to the cache current size as the start index of which HTTP post data from queue. So, when post measures through HTTP its not sending measures that already sent
- Add documentation regarding Transmission (payload and how it transmit data) on `README.md`