### PR TITLE
Keep status led ON every sleep cycle when ledTestRequested is set from remote configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,23 +55,25 @@ Payload format is sent based on what is the network options
 
 Device operates on a regular schedule, attempting to send payload every 9 minutes. Each payload contains a set of comma-separated values. The first value is an **`interval`** number in seconds, which serves as a reference for the timestamping of the subsequent measurements. After that, the payload contains three distinct sets of sensor measurements. Each set represents a snapshot of the device's sensor readings taken at a 3-minute interval. The measurements are always in the same order:
 
-- CO2
-- Temperature
-- Humidity
-- PM1.0
-- PM2.5
-- PM10
-- TVOC
-- NOx
+- CO2 (ppm)
+- Temperature (°C) multiply by 10 
+- Humidity (%) multiply by 10
+- PM1.0 (μg/m³) multiply by 10
+- PM2.5 (μg/m³) multiply by 10
+- PM10 (μg/m³) multiply by 10
+- TVOC (Raw)
+- NOx (Raw)
 - PM 0.3 Particle Count 
-- Signal Strength in dbm
-- Battery Voltage in V
-- Solar Panel Voltage in V
-- O3 Working Electrode (WE) in mV → _O-M-1PPSTON-CE_ only
-- O3 Auxiliary Electrode (AE) in mV → _O-M-1PPSTON-CE_ only
-- NO2 Working Electrode (WE) in mV → _O-M-1PPSTON-CE_ only
-- NO2 Auxiliary Electrode (AE) in mV → _O-M-1PPSTON-CE_ only
-- AFE Temperature in mV → _O-M-1PPSTON-CE_ only
+- Signal Strength (dbm)
+- Battery Voltage (V) multiply by 100
+- Solar Panel Voltage (V) multiply by 100
+- O3 Working Electrode (mV) multiply by 1000 → _O-M-1PPSTON-CE_ only
+- O3 Auxiliary Electrode (mV) multiply by 1000 → _O-M-1PPSTON-CE_ only
+- NO2 Working Electrode (mV) multiply by 1000 → _O-M-1PPSTON-CE_ only
+- NO2 Auxiliary Electrode (mV) multiply by 1000 → _O-M-1PPSTON-CE_ only
+- AFE Temperature (mV) multiply by 10 → _O-M-1PPSTON-CE_ only
+
+**Data Scaling for Efficiency**
 
 To reduce the payload size and still maintain precision for decimal values, certain measurements are scaled up before transmission. To get the actual reading, these value must be divided by a specific factor:
 
@@ -80,6 +82,8 @@ To reduce the payload size and still maintain precision for decimal values, cert
 - **Divide by 1000**: `O3 WE`, `O3 AE`, `NO2 WE`, and `NO2 AE`.
 
 For example, a transmitted `Temperature` value of `285` should be divided by 10 to get the actual reading of `28.5`.
+
+**Example Payload Breakdown**
 
 A typical payload might look like this:
 

--- a/README.md
+++ b/README.md
@@ -65,15 +65,21 @@ Device operates on a regular schedule, attempting to send payload every 9 minute
 - NOx
 - PM 0.3 Particle Count 
 - Signal Strength in dbm
-- Battery Voltage in mV
-- Solar Panel Voltage in mV
+- Battery Voltage in V
+- Solar Panel Voltage in V
 - O3 Working Electrode (WE) in mV → _O-M-1PPSTON-CE_ only
 - O3 Auxiliary Electrode (AE) in mV → _O-M-1PPSTON-CE_ only
 - NO2 Working Electrode (WE) in mV → _O-M-1PPSTON-CE_ only
 - NO2 Auxiliary Electrode (AE) in mV → _O-M-1PPSTON-CE_ only
 - AFE Temperature in mV → _O-M-1PPSTON-CE_ only
 
-**Example Payload Breakdown**
+To reduce the payload size and still maintain precision for decimal values, certain measurements are scaled up before transmission. To get the actual reading, these value must be divided by a specific factor:
+
+- **Divide by 10**: `Temperature`, `Humidity`, `PM1.0`, `PM2.5`, `PM10`, and `AFE Temperature`.
+- **Divide by 100**: `Battery Voltage` and `Solar Panel Voltage`.
+- **Divide by 1000**: `O3 WE`, `O3 AE`, `NO2 WE`, and `NO2 AE`.
+
+For example, a transmitted `Temperature` value of `285` should be divided by 10 to get the actual reading of `28.5`.
 
 A typical payload might look like this:
 
@@ -87,16 +93,6 @@ In this example:
 - `452,...,5796` → The first measurements set 
 - `450,...,5795` → The second measurements set 
 - `446,...,5796` → The third measurements set 
-
-**Data Scaling for Efficiency**
-
-To reduce the payload size and still maintain precision for decimal values, certain measurements are scaled up before transmission. Developers must divide these values by a specific factor to get the actual reading:
-
-- **Divide by 10**: `Temperature`, `Humidity`, `PM1.0`, `PM2.5`, `PM10`, and `AFE Temperature`.
-- **Divide by 100**: `Battery Voltage` and `Solar Panel Voltage`.
-- **Divide by 1000**: `O3 WE`, `O3 AE`, `NO2 WE`, and `NO2 AE`.
-
-For example, a transmitted `Temperature` value of `285` should be divided by 10 to get the actual reading of `28.5`.
 
 
 **Handling Data Loss**

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Payload format is sent based on what is the network options
 
 > Applied when transmit through HTTP and MQTT
 
-Device operates on a regular schedule, attempting to send payload every 9 minutes. Each payload contains a set of comma-separated values. The first value is an **`interval`** number, which serves as a reference for the timestamping of the subsequent measurements. After that, the payload contains three distinct sets of sensor measurements. Each set represents a snapshot of the device's sensor readings taken at a 3-minute interval. The measurements are always in the same order:
+Device operates on a regular schedule, attempting to send payload every 9 minutes. Each payload contains a set of comma-separated values. The first value is an **`interval`** number in seconds, which serves as a reference for the timestamping of the subsequent measurements. After that, the payload contains three distinct sets of sensor measurements. Each set represents a snapshot of the device's sensor readings taken at a 3-minute interval. The measurements are always in the same order:
 
 - CO2
 - Temperature
@@ -65,13 +65,13 @@ Device operates on a regular schedule, attempting to send payload every 9 minute
 - NOx
 - PM 0.3 Particle Count 
 - Signal Strength in dbm
-- Battery Voltage
-- Solar Panel Voltage
-- O3 Working Electrode (WE) → _O-M-1PPSTON-CE_ only
-- O3 Auxiliary Electrode (AE) → _O-M-1PPSTON-CE_ only
-- NO2 Working Electrode (WE) → _O-M-1PPSTON-CE_ only
-- NO2 Auxiliary Electrode (AE) → _O-M-1PPSTON-CE_ only
-- AFE Temperature → _O-M-1PPSTON-CE_ only
+- Battery Voltage in mV
+- Solar Panel Voltage in mV
+- O3 Working Electrode (WE) in mV → _O-M-1PPSTON-CE_ only
+- O3 Auxiliary Electrode (AE) in mV → _O-M-1PPSTON-CE_ only
+- NO2 Working Electrode (WE) in mV → _O-M-1PPSTON-CE_ only
+- NO2 Auxiliary Electrode (AE) in mV → _O-M-1PPSTON-CE_ only
+- AFE Temperature in mV → _O-M-1PPSTON-CE_ only
 
 **Example Payload Breakdown**
 
@@ -83,7 +83,7 @@ A typical payload might look like this:
 
 In this example:
 
-- `180` → The `interval` value at the start
+- `180` → The `interval` value at the start in seconds
 - `452,...,5796` → The first measurements set 
 - `450,...,5795` → The second measurements set 
 - `446,...,5796` → The third measurements set 

--- a/main/Configuration.cpp
+++ b/main/Configuration.cpp
@@ -112,12 +112,11 @@ bool Configuration::parseRemoteConfig(const std::string &config) {
   }
 
   // ledTestRequested
-  if (root["ledTestRequested"].is<bool>()) {
-    bool_val = root["ledTestRequested"].as<bool>();
-    if (_config.ledTestRequested != bool_val) {
-      ESP_LOGI(TAG, "ledTestRequested value changed to %d", bool_val);
+  if (root["ledBarTestRequested"].is<bool>()) {
+    bool_val = root["ledBarTestRequested"].as<bool>();
+    if (bool_val) {
+      ESP_LOGI(TAG, "Led test is requested");
       _config.ledTestRequested = bool_val;
-      _configChanged = true;
     }
   } else {
     ESP_LOGW(TAG, "ledTestRequested field not found or not a boolean");
@@ -244,15 +243,6 @@ bool Configuration::_loadConfig() {
     _config.co2CalibrationRequested = co2CalibrationRequested;
   } else {
     ESP_LOGW(TAG, "Failed to get co2CalibrationRequested");
-  }
-
-  // LED TEST
-  uint8_t ledTestRequested;
-  err = nvs_get_u8(handle, NVS_KEY_LED_TEST_REQUESTED, &ledTestRequested);
-  if (err == ESP_OK) {
-    _config.ledTestRequested = ledTestRequested;
-  } else {
-    ESP_LOGW(TAG, "Failed to get ledTestRequested");
   }
 
   // ABC DAYS
@@ -413,12 +403,6 @@ bool Configuration::_saveConfig() {
     ESP_LOGW(TAG, "Failed to save co2CalibrationRequested");
   }
 
-  // LED TEST
-  err = nvs_set_u8(handle, NVS_KEY_LED_TEST_REQUESTED, _config.ledTestRequested);
-  if (err != ESP_OK) {
-    ESP_LOGW(TAG, "Failed to save ledTestRequested");
-  }
-
   // ABC DAYS
   err = nvs_set_u16(handle, NVS_KEY_ABC_DAYS, _config.abcDays);
   if (err != ESP_OK) {
@@ -556,11 +540,6 @@ void Configuration::setRunSystemSettings(bool state) {
 
 void Configuration::setAPN(const std::string &apn) {
   _config.apn = apn;
-  _saveConfig();
-}
-
-void Configuration::resetLedTestRequest() {
-  _config.ledTestRequested = false;
   _saveConfig();
 }
 

--- a/main/Configuration.h
+++ b/main/Configuration.h
@@ -29,7 +29,7 @@ public:
     // Remote
     int abcDays;
     bool co2CalibrationRequested;
-    bool ledTestRequested;
+    bool ledTestRequested; // Not saved to NVS
     std::string model;
     Schedule schedule;
     Firmware firmware;
@@ -69,7 +69,6 @@ public:
   void setRunSystemSettings(bool state);
   void setAPN(const std::string &apn);
 
-  void resetLedTestRequest();
   void resetCO2CalibrationRequest();
 
 private:

--- a/main/StatusLed.cpp
+++ b/main/StatusLed.cpp
@@ -52,9 +52,9 @@ void StatusLed::stop() {
   }
 }
 
-void StatusLed::enable() { gpio_hold_en(_ioLed); }
+void StatusLed::holdState() { gpio_hold_en(_ioLed); }
 
-void StatusLed::disable() { gpio_hold_dis(_ioLed); }
+void StatusLed::releaseState() { gpio_hold_dis(_ioLed); }
 
 void StatusLed::on() { set(On); }
 

--- a/main/StatusLed.cpp
+++ b/main/StatusLed.cpp
@@ -38,8 +38,6 @@ esp_err_t StatusLed::start() {
   }
   _isRunning = true;
 
-  // gpio_hold_dis(_ioLed);
-  // gpio_reset_pin(_ioLed);
   gpio_set_direction(_ioLed, GPIO_MODE_OUTPUT);
   gpio_set_level(_ioLed, 0);
 
@@ -54,10 +52,9 @@ void StatusLed::stop() {
   }
 }
 
-void StatusLed::disable() {
-  gpio_set_level(_ioLed, 0);
-  // gpio_hold_en(_ioLed);
-}
+void StatusLed::enable() { gpio_hold_en(_ioLed); }
+
+void StatusLed::disable() { gpio_hold_dis(_ioLed); }
 
 void StatusLed::on() { set(On); }
 

--- a/main/StatusLed.h
+++ b/main/StatusLed.h
@@ -26,8 +26,8 @@ public:
 
   esp_err_t start();
   void stop();
-  void enable();
-  void disable();
+  void holdState();
+  void releaseState();
 
   void on();
   void off();

--- a/main/StatusLed.h
+++ b/main/StatusLed.h
@@ -26,6 +26,7 @@ public:
 
   esp_err_t start();
   void stop();
+  void enable();
   void disable();
 
   void on();

--- a/main/max.cpp
+++ b/main/max.cpp
@@ -313,6 +313,12 @@ extern "C" void app_main(void) {
   checkRemoteConfiguration(wakeUpCounter);
   checkForFirmwareUpdate(wakeUpCounter);
 
+  // If led test requested, keep led ON until its power cycled 
+  if (g_configuration.isLedTestRequested()) {
+    g_statusLed.on();
+    g_statusLed.holdState();
+  }
+
   // Turn of network network
   if (g_configuration.getNetworkOption() == NetworkOption::Cellular) {
     // Only poweroff when all transmission attempt is done
@@ -340,14 +346,7 @@ extern "C" void app_main(void) {
   esp_sleep_enable_timer_wakeup(toSleepMs * 1000);
   vTaskDelay(pdMS_TO_TICKS(1000));
 
-  // Keep status led ON until ledTestRequested is unset from remote configuration
-  if (g_configuration.isLedTestRequested()) {
-    g_statusLed.on();
-    g_statusLed.holdState();
-  } else {
-    g_statusLed.off();
-    g_statusLed.releaseState();
-  }
+  g_statusLed.off();
 
   esp_deep_sleep_start();
 

--- a/main/max.cpp
+++ b/main/max.cpp
@@ -340,13 +340,13 @@ extern "C" void app_main(void) {
   esp_sleep_enable_timer_wakeup(toSleepMs * 1000);
   vTaskDelay(pdMS_TO_TICKS(1000));
 
-  // Keep status led ON every sleep cycle when ledTestRequested is set from remote configuration
+  // Keep status led ON until ledTestRequested is unset from remote configuration
   if (g_configuration.isLedTestRequested()) {
     g_statusLed.on();
-    g_statusLed.enable();
+    g_statusLed.holdState();
   } else {
     g_statusLed.off();
-    g_statusLed.disable();
+    g_statusLed.releaseState();
   }
 
   esp_deep_sleep_start();

--- a/main/max.cpp
+++ b/main/max.cpp
@@ -237,12 +237,6 @@ extern "C" void app_main(void) {
     wakeUpMillis = MILLIS();
   }
 
-  // Run led test if requested
-  if (g_configuration.isLedTestRequested()) {
-    g_statusLed.blink(5000, 100);
-    g_configuration.resetLedTestRequest();
-  }
-
   // Reset external WDT
   resetExtWatchdog();
 
@@ -345,7 +339,16 @@ extern "C" void app_main(void) {
   ESP_LOGI(TAG, "Will sleep for %dms", toSleepMs);
   esp_sleep_enable_timer_wakeup(toSleepMs * 1000);
   vTaskDelay(pdMS_TO_TICKS(1000));
-  g_statusLed.disable();
+
+  // Keep status led ON every sleep cycle when ledTestRequested is set from remote configuration
+  if (g_configuration.isLedTestRequested()) {
+    g_statusLed.on();
+    g_statusLed.enable();
+  } else {
+    g_statusLed.off();
+    g_statusLed.disable();
+  }
+
   esp_deep_sleep_start();
 
   // Will never go here
@@ -839,7 +842,7 @@ bool sendMeasuresByWiFi(unsigned long wakeUpCounter,
 }
 
 bool sendMeasuresUsingMqtt(unsigned long wakeUpCounter, PayloadCache &payloadCache) {
-  // Sanity check if MQTT is enabled 
+  // Sanity check if MQTT is enabled
   std::string uri = g_configuration.getMqttBrokerUrl();
   if (uri.empty()) {
     return true;


### PR DESCRIPTION
## Changes

If `ledBarTestRequested` from remote configuration is set, Led Notification will keep ON until its power cycled