### PR TITLE
Update BQ25672 getVBUSRaw to prioritize ADC1 over ADC2

### DIFF
--- a/components/BQ25672/BQ25672.cpp
+++ b/components/BQ25672/BQ25672.cpp
@@ -29,7 +29,8 @@
 #define REG3C_BAT_PCT 0x3F
 #define REG3F_TEMP_ADC 0x41
 #define REG33_IBAT_ADC 0x33 // Register Address for IBAT ADC
-#define REG39_VBUS_ADC 0x39 // VBUS ADC Register
+#define REG37_VBUS_ADC1 0x37 // Register Address for VBUS ADC1
+#define REG39_VBUS_ADC2 0x39 // Register Address for VBUS ADC2
 #define REG15_MPPT 0x15
 #define REG_SYSTEM_STATUS 0x0A
 #define REG_FAULT_STATUS 0x0B
@@ -235,12 +236,23 @@ esp_err_t BQ25672::getTemperatureRaw(uint16_t *output) {
 }
 
 esp_err_t BQ25672::getVBUSRaw(uint16_t *output) {
-  ESP_RETURN_ON_ERROR(writeReadRegister(REG39_VBUS_ADC, 2, output), TAG, "Failed get VBUS raw");
+  // First try reading from ADC1
+  uint16_t adc1_value;
+  ESP_RETURN_ON_ERROR(writeReadRegister(REG37_VBUS_ADC1, 2, &adc1_value), TAG, "Failed get VBUS ADC1");
+  
+  // If ADC1 value is >= 1, use it
+  if (adc1_value >= 1000) {
+    *output = adc1_value;
+    return ESP_OK;
+  }
+  
+  // Otherwise, fall back to ADC2
+  ESP_RETURN_ON_ERROR(writeReadRegister(REG39_VBUS_ADC2, 2, output), TAG, "Failed get VBUS ADC2");
   return ESP_OK;
 }
 
 esp_err_t BQ25672::getIBATRaw(uint16_t *output) {
-  ESP_RETURN_ON_ERROR(writeReadRegister(REG39_VBUS_ADC, 2, output), TAG, "Failed get raw IBAT");
+  ESP_RETURN_ON_ERROR(writeReadRegister(REG39_VBUS_ADC2, 2, output), TAG, "Failed get raw IBAT");
   return ESP_OK;
 }
 

--- a/sdkconfig
+++ b/sdkconfig
@@ -637,12 +637,7 @@ CONFIG_APPTRACE_LOCK_ENABLE=y
 # Bluetooth
 #
 # CONFIG_BT_ENABLED is not set
-
-#
-# Common Options
-#
-# CONFIG_BT_BLE_LOG_SPI_OUT_ENABLED is not set
-# end of Common Options
+CONFIG_BT_ALARM_MAX_NUM=50
 # end of Bluetooth
 
 #
@@ -701,12 +696,6 @@ CONFIG_APPTRACE_LOCK_ENABLE=y
 # CONFIG_I2S_SUPPRESS_DEPRECATE_WARN is not set
 # CONFIG_I2S_SKIP_LEGACY_CONFLICT_CHECK is not set
 # end of Legacy I2S Driver Configurations
-
-#
-# Legacy I2C Driver Configurations
-#
-# CONFIG_I2C_SKIP_LEGACY_CONFLICT_CHECK is not set
-# end of Legacy I2C Driver Configurations
 
 #
 # Legacy PCNT Driver Configurations
@@ -787,7 +776,6 @@ CONFIG_ESP_ERR_TO_NAME_LOOKUP=y
 CONFIG_GPTIMER_ISR_HANDLER_IN_IRAM=y
 # CONFIG_GPTIMER_CTRL_FUNC_IN_IRAM is not set
 # CONFIG_GPTIMER_ISR_IRAM_SAFE is not set
-CONFIG_GPTIMER_OBJ_CACHE_SAFE=y
 # CONFIG_GPTIMER_ENABLE_DEBUG_LOG is not set
 # end of ESP-Driver:GPTimer Configurations
 
@@ -1332,14 +1320,6 @@ CONFIG_FATFS_VFS_FSTAT_BLKSIZE=0
 # CONFIG_FATFS_IMMEDIATE_FSYNC is not set
 # CONFIG_FATFS_USE_LABEL is not set
 CONFIG_FATFS_LINK_LOCK=y
-# CONFIG_FATFS_USE_DYN_BUFFERS is not set
-
-#
-# File system free space calculation behavior
-#
-CONFIG_FATFS_DONT_TRUST_FREE_CLUSTER_CNT=0
-CONFIG_FATFS_DONT_TRUST_LAST_ALLOC=0
-# end of File system free space calculation behavior
 # end of FAT Filesystem support
 
 #
@@ -1737,7 +1717,6 @@ CONFIG_MBEDTLS_HAVE_TIME=y
 # CONFIG_MBEDTLS_PLATFORM_TIME_ALT is not set
 # CONFIG_MBEDTLS_HAVE_TIME_DATE is not set
 CONFIG_MBEDTLS_ECDSA_DETERMINISTIC=y
-CONFIG_MBEDTLS_SHA1_C=y
 CONFIG_MBEDTLS_SHA512_C=y
 # CONFIG_MBEDTLS_SHA3_C is not set
 CONFIG_MBEDTLS_TLS_SERVER_AND_CLIENT=y
@@ -1921,7 +1900,6 @@ CONFIG_SPI_FLASH_BROWNOUT_RESET=y
 # CONFIG_SPI_FLASH_AUTO_SUSPEND is not set
 CONFIG_SPI_FLASH_SUSPEND_TSUS_VAL_US=50
 # CONFIG_SPI_FLASH_FORCE_ENABLE_XMC_C_SUSPEND is not set
-# CONFIG_SPI_FLASH_FORCE_ENABLE_C6_H2_SUSPEND is not set
 # end of Optional and Experimental Features (READ DOCS FIRST)
 # end of Main Flash configuration
 


### PR DESCRIPTION
- Modified getVBUSRaw function to read from ADC1 first
- Falls back to ADC2 if ADC1 value is less than 1000
- Updated sdkconfig accordingly