### PR TITLE
Fix buffering issue occur when more than 20 measures cache

### DIFF
--- a/main/MaxConfig.h
+++ b/main/MaxConfig.h
@@ -17,7 +17,7 @@ enum class NetworkOption {
 
 #define NETWORKING_TASK_STACK_SIZE 16384
 
-#define MAX_PAYLOAD_CACHE 100
+#define MAX_PAYLOAD_CACHE 75
 
 #define MILLIS() ((uint32_t)(esp_timer_get_time() / 1000))
 

--- a/main/max.cpp
+++ b/main/max.cpp
@@ -361,6 +361,11 @@ extern "C" void app_main(void) {
   sensor.startMeasures(DEFAULT_MEASURE_ITERATION_COUNT, DEFAULT_MEASURE_INTERVAL_MS_PER_ITERATION);
   sensor.printMeasures();
   g_measuresResult = sensor.getLastAverageMeasure();
+  // NOTE: Temporary since MAX cannot calculate the index yet. So raw value is assumed index on server.
+  g_measuresResult.common.tvoc = g_measuresResult.common.tvocRaw;
+  g_measuresResult.common.nox = g_measuresResult.common.noxRaw;
+  g_measuresResult.common.tvocRaw = DEFAULT_INVALID_TVOC;
+  g_measuresResult.common.noxRaw = DEFAULT_INVALID_NOX;
 
   // Turn OFF PM sensor load switch
   gpio_set_level(EN_PMS1, 0);

--- a/main/max.cpp
+++ b/main/max.cpp
@@ -980,6 +980,7 @@ bool sendMeasuresByWiFi(unsigned long wakeUpCounter, MaxSensorPayload sensorPayl
   AirgradientClient::AirgradientPayload payload;
   payload.payloadBuffer[0].common = sensorPayload.common;
   payload.payloadBuffer[0].ext.extra = sensorPayload.extra;
+  payload.bufferCount = 1;
   payload.signal = getNetworkSignalStrength();
   ESP_LOGI(TAG, "Signal strength: %d", payload.signal);
 
@@ -1101,7 +1102,14 @@ bool checkRemoteConfiguration(unsigned long wakeUpCounter) {
   }
 
   // Attempt retrieve configuration
-  std::string result = g_agClient->coapFetchConfig();
+  std::string result;
+  if (g_configuration.getNetworkOption() == NetworkOption::Cellular) {
+    result = g_agClient->coapFetchConfig();
+  }
+  else {
+    result = g_agClient->httpFetchConfig();
+  }
+
   if (g_agClient->isRegisteredOnAgServer() == false) {
     ESP_LOGW(TAG, "Monitor hasn't registered on AirGradient dashboard yet");
     return false;


### PR DESCRIPTION
## Changes

1. Bump AirgradientClient: fix buffering issue occur when more than 20 measures cache
2. Temporarily map TVOC and NOx raw value as the index
3. Fix wifi post measures and fetch config issue