### PR TITLE
Fix cellular registration stuck on stale operator list across wake cycles

### DIFF
--- a/main/Configuration.cpp
+++ b/main/Configuration.cpp
@@ -33,6 +33,7 @@
 #define NVS_KEY_CELLULAR_WARMUP "warmUpCE"
 #define NVS_KEY_CELLULAR_OPERATORS "cellOps"
 #define NVS_KEY_CURRENT_OPERATOR_ID "cellOpId"
+#define NVS_KEY_CELLULAR_REG_FAIL_COUNT "cellRegFail"
 
 bool Configuration::load() {
   // At first, set every configuration to default
@@ -72,6 +73,7 @@ void Configuration::_printConfig() {
   ESP_LOGI(TAG, "cellularWarmUpMs: %" PRIu32 "", _config.cellularWarmUpMs);
   ESP_LOGI(TAG, "cellularOperators: %s", _config.cellularOperators.c_str());
   ESP_LOGI(TAG, "currentOperatorId: %" PRIu32 "", _config.currentOperatorId);
+  ESP_LOGI(TAG, "cellularRegFailCount: %" PRIu32 "", _config.cellularRegFailCount);
   ESP_LOGI(TAG, "**** ****");
 }
 
@@ -484,6 +486,15 @@ bool Configuration::_loadConfig() {
     ESP_LOGW(TAG, "Failed to get currentOperatorId");
   }
 
+  // Cellular Registration Fail Count
+  uint32_t cellularRegFailCount;
+  err = nvs_get_u32(handle, NVS_KEY_CELLULAR_REG_FAIL_COUNT, &cellularRegFailCount);
+  if (err == ESP_OK) {
+    _config.cellularRegFailCount = cellularRegFailCount;
+  } else {
+    ESP_LOGW(TAG, "Failed to get cellularRegFailCount");
+  }
+
   // Close NVS
   nvs_close(handle);
 
@@ -601,6 +612,12 @@ bool Configuration::_saveConfig() {
     ESP_LOGW(TAG, "Failed to save currentOperatorId");
   }
 
+  // Cellular Registration Fail Count
+  err = nvs_set_u32(handle, NVS_KEY_CELLULAR_REG_FAIL_COUNT, _config.cellularRegFailCount);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "Failed to save cellularRegFailCount");
+  }
+
   // Commit changes
   ESP_LOGI(TAG, "Commit changes to NVS");
   err = nvs_commit(handle);
@@ -659,6 +676,8 @@ std::string Configuration::getCellularOperators() { return _config.cellularOpera
 
 uint32_t Configuration::getCurrentOperatorId() { return _config.currentOperatorId; }
 
+uint32_t Configuration::getCellularRegFailCount() { return _config.cellularRegFailCount; }
+
 bool Configuration::set(Config config) {
   _config = config;
   _printConfig();
@@ -685,7 +704,8 @@ void Configuration::setAPN(const std::string &apn) {
   _saveConfig();
 }
 
-void Configuration::setCellularOperators(const std::string &operators, uint32_t operatorId) {
+void Configuration::setCellularOperators(const std::string &operators, uint32_t operatorId,
+                                          uint32_t regFailCount) {
   bool changed = false;
   if (_config.cellularOperators != operators) {
     ESP_LOGI(TAG, "Cellular operator list changed, saving it");
@@ -695,6 +715,11 @@ void Configuration::setCellularOperators(const std::string &operators, uint32_t 
   if (_config.currentOperatorId != operatorId) {
     ESP_LOGI(TAG, "Current cellular operator ID changed, saving it");
     _config.currentOperatorId = operatorId;
+    changed = true;
+  }
+  if (_config.cellularRegFailCount != regFailCount) {
+    ESP_LOGI(TAG, "Cellular registration fail count changed to %" PRIu32, regFailCount);
+    _config.cellularRegFailCount = regFailCount;
     changed = true;
   }
 
@@ -728,4 +753,5 @@ void Configuration::_setConfigToDefault() {
   _config.cellularWarmUpMs = 6000;
   _config.cellularOperators = "";
   _config.currentOperatorId = 0;
+  _config.cellularRegFailCount = 0;
 }

--- a/main/Configuration.h
+++ b/main/Configuration.h
@@ -45,6 +45,7 @@ public:
     uint32_t cellularWarmUpMs;
     std::string cellularOperators;
     uint32_t currentOperatorId;
+    uint32_t cellularRegFailCount;
   };
 
   Configuration() {}
@@ -72,6 +73,7 @@ public:
   uint32_t getCellularWarmUpMs();
   std::string getCellularOperators();
   uint32_t getCurrentOperatorId();
+  uint32_t getCellularRegFailCount();
 
   // Setter
   bool set(Config config);
@@ -79,7 +81,8 @@ public:
   void setIsWifiConfigured(bool state);
   void setRunSystemSettings(bool state);
   void setAPN(const std::string &apn);
-  void setCellularOperators(const std::string &operators, uint32_t operatorId);
+  void setCellularOperators(const std::string &operators, uint32_t operatorId,
+                            uint32_t regFailCount);
 
   void resetCO2CalibrationRequest();
 

--- a/main/max.cpp
+++ b/main/max.cpp
@@ -770,10 +770,11 @@ bool initializeNetwork(unsigned long wakeUpCounter) {
 
   if (g_configuration.getNetworkOption() == NetworkOption::Cellular) {
     g_networkReady = initializeCellularNetwork(wakeUpCounter);
-    // Ensure operator always up to date
+    // Persist operator state and fail counter (library manages the clearing logic)
     std::string opList = g_cellularCard->getSerializedOperators();
     uint32_t opId = g_cellularCard->getCurrentOperatorId();
-    g_configuration.setCellularOperators(opList, opId);
+    uint32_t failCount = g_cellularCard->getRegistrationFailCount();
+    g_configuration.setCellularOperators(opList, opId, failCount);
   } else {
     g_networkReady = initializeWiFiNetwork(wakeUpCounter);
   }
@@ -821,9 +822,10 @@ bool initializeCellularNetwork(unsigned long wakeUpCounter) {
 
   resetExtWatchdog();
 
-  // Load and set CE module operators
+  // Load and set CE module operators (including persisted fail counter)
   g_cellularCard->setOperators(g_configuration.getCellularOperators(),
-                               g_configuration.getCurrentOperatorId());
+                               g_configuration.getCurrentOperatorId(),
+                               g_configuration.getCellularRegFailCount());
 
   // Setup client configuration
   g_agClient->setHttpDomain(g_configuration.getHttpDomain());


### PR DESCRIPTION
## Problem
On wake cycles, cellular registration would retry the same stale operator list indefinitely. The exhaustion counter reset every call, and the resume position always jumped back to the last successful operator -- never progressing through the full list.

## Changes
- Add `cellularRegFailCount` to NVS configuration for persistence across deep sleep
- Pass fail counter to/from AirgradientClient library via `setOperators()` / `getRegistrationFailCount()`
- After 3 consecutive full-list exhaustions, the library clears the operator list, triggering a fresh scan on the next attempt