### PR TITLE
Calculate TVOC and NOx index on MAX

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -3,6 +3,7 @@ set(srcs
   "StatusLed.cpp"
   "Sensor.cpp"
   "PayloadCache.cpp"
+  "GasIndex.cpp"
   "Configuration.cpp"
   "AlphaSenseSensor.cpp"
 )

--- a/main/GasIndex.cpp
+++ b/main/GasIndex.cpp
@@ -1,0 +1,63 @@
+/**
+ * AirGradient
+ * https://airgradient.com
+ *
+ * CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
+ */
+
+#include "GasIndex.h"
+
+#include "esp_attr.h"
+#include "esp_log.h"
+
+#include "MaxConfig.h"
+#include "sensirion_gas_index_algorithm.h"
+
+// Algorithm states persisted across deep sleep in RTC memory so the estimator
+// keeps learning between wake cycles.
+RTC_DATA_ATTR GasIndexAlgorithmParams rtcVocParams;
+RTC_DATA_ATTR GasIndexAlgorithmParams rtcNoxParams;
+
+void GasIndex::init(bool firstBoot) {
+  if (!firstBoot) {
+    // States already restored from RTC memory, nothing to do
+    return;
+  }
+
+  GasIndexAlgorithm_init_with_sampling_interval(
+      &rtcVocParams, GasIndexAlgorithm_ALGORITHM_TYPE_VOC,
+      GAS_INDEX_SAMPLING_INTERVAL_SEC);
+  GasIndexAlgorithm_init_with_sampling_interval(
+      &rtcNoxParams, GasIndexAlgorithm_ALGORITHM_TYPE_NOX,
+      GAS_INDEX_SAMPLING_INTERVAL_SEC);
+
+  ESP_LOGI(TAG,
+           "Initialized VOC & NOx algorithm at %.0fs interval (RTC state: %u "
+           "bytes each)",
+           GAS_INDEX_SAMPLING_INTERVAL_SEC,
+           (unsigned)sizeof(GasIndexAlgorithmParams));
+}
+
+void GasIndex::process(int tvocRaw, int noxRaw, int *tvocIndex, int *noxIndex) {
+  if (IS_TVOC_VALID(tvocRaw)) {
+    int32_t index = 0;
+    GasIndexAlgorithm_process(&rtcVocParams, tvocRaw, &index);
+    *tvocIndex = index;
+    ESP_LOGI(TAG, "TVOC index: %d", (int)index);
+  } else {
+    // Skip processing to avoid poisoning the estimator with invalid input
+    *tvocIndex = DEFAULT_INVALID_TVOC;
+    ESP_LOGW(TAG, "Invalid TVOC raw, skip index calculation");
+  }
+
+  if (IS_NOX_VALID(noxRaw)) {
+    int32_t index = 0;
+    GasIndexAlgorithm_process(&rtcNoxParams, noxRaw, &index);
+    *noxIndex = index;
+    ESP_LOGI(TAG, "NOx index: %d", (int)index);
+  } else {
+    // Skip processing to avoid poisoning the estimator with invalid input
+    *noxIndex = DEFAULT_INVALID_NOX;
+    ESP_LOGW(TAG, "Invalid NOx raw, skip index calculation");
+  }
+}

--- a/main/GasIndex.h
+++ b/main/GasIndex.h
@@ -1,0 +1,39 @@
+/**
+ * AirGradient
+ * https://airgradient.com
+ *
+ * CC BY-SA 4.0 Attribution-ShareAlike 4.0 International License
+ */
+
+#ifndef GAS_INDEX_H
+#define GAS_INDEX_H
+
+// Sampling interval fed to the Sensirion Gas Index Algorithm.
+// MAX wakes every ~3 minutes, so the algorithm is processed once per cycle.
+// NOTE: Not the ideal 1s/10s interval; server does post-processing.
+#define GAS_INDEX_SAMPLING_INTERVAL_SEC 180.0f
+
+class GasIndex {
+public:
+  GasIndex() {}
+  ~GasIndex() {}
+
+  /**
+   * Initialize the VOC and NOx algorithm states.
+   * On first boot, states are (re)initialized. On wake from deep sleep the
+   * states are already restored from RTC memory, so this is a no-op.
+   */
+  void init(bool firstBoot);
+
+  /**
+   * Convert raw SGP41 signals to VOC/NOx index values.
+   * Invalid raw inputs (DEFAULT_INVALID_*) are skipped to avoid poisoning the
+   * estimator, and the corresponding index output is set to invalid.
+   */
+  void process(int tvocRaw, int noxRaw, int *tvocIndex, int *noxIndex);
+
+private:
+  const char *const TAG = "GasIndex";
+};
+
+#endif // !GAS_INDEX_H

--- a/main/MaxConfig.h
+++ b/main/MaxConfig.h
@@ -17,7 +17,9 @@ enum class NetworkOption {
 
 #define NETWORKING_TASK_STACK_SIZE 16384
 
-#define MAX_PAYLOAD_CACHE 75
+// Reduced from 75: traded 4 cache entries (~464 B) for the two RTC-persisted
+// gas index algorithm states (VOC + NOx) used to calculate TVOC/NOx index.
+#define MAX_PAYLOAD_CACHE 71
 
 #define MILLIS() ((uint32_t)(esp_timer_get_time() / 1000))
 

--- a/main/Sensor.cpp
+++ b/main/Sensor.cpp
@@ -387,10 +387,15 @@ void Sensor::_measure(int iteration, MaxSensorPayload &data) {
   }
 
   if (_tvocNoxAvailable) {
+    // SGP4x requires valid compensation; fall back to sensor defaults
+    // (25C/50%RH) when SHT read is unavailable/failed, otherwise the raw read
+    // is rejected as out of range.
+    float compT = IS_TEMPERATURE_VALID(data.common.atmp) ? data.common.atmp : 25.0f;
+    float compRh = IS_HUMIDITY_VALID(data.common.rhum) ? data.common.rhum : 50.0f;
     uint16_t tvocRaw;
     uint16_t noxRaw;
     esp_err_t result =
-        sgp4x_measure_compensated_signals(sgp_dev_hdl, data.common.atmp, data.common.rhum, &tvocRaw, &noxRaw);
+        sgp4x_measure_compensated_signals(sgp_dev_hdl, compT, compRh, &tvocRaw, &noxRaw);
     if (result != ESP_OK) {
       ESP_LOGE(TAG, "sgp4x device conditioning failed (%s)", esp_err_to_name(result));
     } else {

--- a/main/max.cpp
+++ b/main/max.cpp
@@ -35,6 +35,7 @@
 #include "MaxConfig.h"
 #include "Configuration.h"
 #include "PayloadCache.h"
+#include "GasIndex.h"
 #include "StatusLed.h"
 #include "Sensor.h"
 #include "AirgradientSerial.h"
@@ -80,6 +81,7 @@ static std::string g_serialNumber;
 static bool g_networkReady = false;
 static std::string g_fimwareVersion;
 static PayloadCache g_payloadCache(MAX_PAYLOAD_CACHE);
+static GasIndex g_gasIndex;
 static Configuration g_configuration;
 static StatusLed g_statusLed(IO_LED_INDICATOR);
 static AirgradientSerial *g_ceAgSerial = nullptr;
@@ -308,6 +310,10 @@ extern "C" void app_main(void) {
   // Restore cache from RTC memory
   g_payloadCache.restoreFromRTC();
 
+  // Initialize gas index algorithm (VOC & NOx). On wake from sleep the states
+  // are already restored from RTC memory, so init only runs on first boot.
+  g_gasIndex.init(xWakeUpCounter == 0);
+
   // Optimization: copy from LP memory so will not always call from LP memory
   int wakeUpCounter = xWakeUpCounter;
 
@@ -363,11 +369,14 @@ extern "C" void app_main(void) {
   sensor.startMeasures(DEFAULT_MEASURE_ITERATION_COUNT, DEFAULT_MEASURE_INTERVAL_MS_PER_ITERATION);
   sensor.printMeasures();
   g_measuresResult = sensor.getLastAverageMeasure();
-  // NOTE: Temporary since MAX cannot calculate the index yet. So raw value is assumed index on server.
-  g_measuresResult.common.tvoc = g_measuresResult.common.tvocRaw;
-  g_measuresResult.common.nox = g_measuresResult.common.noxRaw;
-  g_measuresResult.common.tvocRaw = DEFAULT_INVALID_TVOC;
-  g_measuresResult.common.noxRaw = DEFAULT_INVALID_NOX;
+  // Calculate VOC/NOx index from the averaged raw signals. Raw values are kept
+  // and sent alongside the calculated index.
+  int tvocIndex = DEFAULT_INVALID_TVOC;
+  int noxIndex = DEFAULT_INVALID_NOX;
+  g_gasIndex.process(g_measuresResult.common.tvocRaw, g_measuresResult.common.noxRaw, &tvocIndex,
+                     &noxIndex);
+  g_measuresResult.common.tvoc = tvocIndex;
+  g_measuresResult.common.nox = noxIndex;
 
   // Turn OFF PM sensor load switch
   gpio_set_level(EN_PMS1, 0);


### PR DESCRIPTION
### Summary

MAX now computes real VOC and NOx **index** values from the SGP41 raw signals instead of forwarding raw as index. The Sensirion Gas Index Algorithm runs once per wake cycle (fixed 180 s sampling), with its VOC/NOx state persisted in RTC memory so the estimator keeps learning across deep sleep.

### Changes

- Added `GasIndex` module: two RTC-persisted algorithm states (VOC + NOx), init on first boot, process per wake, guards invalid raw input, logs calculated index.
- `max.cpp` now sends both raw and calculated index (replaces the previous raw-as-index placeholder).
- Reduced `MAX_PAYLOAD_CACHE` 75 → 71 to free RTC space for the two algorithm state structs.
- Fixed SGP41 read: fall back to default compensation (25 °C / 50 %RH) when the SHT read is invalid, which previously aborted the raw read as out-of-range.

### Validation

- Verify device logs valid `SRAW VOC/NOX` and calculated TVOC/NOx index each cycle.
- Verify first-boot log reports `sizeof(GasIndexAlgorithmParams)` within the freed RTC budget.
- Verify index persists/advances across deep-sleep wake cycles.